### PR TITLE
updated map link in footer. added target blank so users don't get tak…

### DIFF
--- a/includes/footer.html
+++ b/includes/footer.html
@@ -6,7 +6,7 @@
 							<header>
 								<h3><a href="mailto:info@omnicommons.org">info@omnicommons.org</a></h3>
 								<h3>Omni Commons | <a href="https://omnicommons.org">omnicommons.org</a></h3>
-								<h3><a href="http://oaklandwiki.org/map/The_Omni">4799 Shattuck Avenue, Oakland, CA, 94609</a></h3>
+								<h3><a href="https://www.google.com/maps/place/4799+Shattuck+Ave,+Oakland,+CA+94609/data=!4m2!3m1!1s0x80857de1eb0c0627:0xb6a09d2a1f78aae7?sa=X&ved=0CB4Q8gEwAGoVChMIgKPhssT3xgIVzZeICh2NjgZN" target="_blank">4799 Shattuck Avenue, Oakland, CA, 94609</a></h3>
 							</header>
 <!--							<ul class="icons">
 								<li><a href="#" class="fa fa-twitter solo"><span>Twitter</span></a></li>

--- a/includes/nav.html
+++ b/includes/nav.html
@@ -29,7 +29,7 @@
 							</li>
 							<li><a href="https://omnicommons.org/wiki/Welcome">Wiki</a></li>
 							<li><a href="https://omnicommons.org/calendar">Calendar</a></li>
-							<li><a href="https://omnicommons.org/donate" class="scrolly">Donate</a>
+							<li><a href="https://omnicommons.org/donate" class="scrolly" target="_blank" title="Donate to Omni Commons">Donate</a>
 								<ul>
 									<li><a href="friends.html">Friends of Omni Commons</a></li>
 								</ul>


### PR DESCRIPTION
updated map link in footer. added target blank so users don't get taken away from the omnicommons site, as well as replaced the map link with the google map so that users can easily get directions to the commons.

I know this is a small change. I'm learning to fork github projects and contribute to projects, which is why I'm starting small. :)
